### PR TITLE
fixes #3

### DIFF
--- a/util.py
+++ b/util.py
@@ -33,4 +33,4 @@ def crop_to(image_to_crop, reference_image):
     upper = dy / 2
     right = dx / 2 + reference_size[0]
     lower = dy / 2 + reference_size[1]
-    return image_to_crop.crop(box=(left, upper, right, lower))
+    return image_to_crop.crop(box=(int(left), int(upper), int(right), int(lower)))


### PR DESCRIPTION
Explicitly convert passed parameters to `int` in `crop` call.

This should now work:

```bash
$ python3 pixelsort.py -a 90 examples/file.png 
Interval function:  threshold
Lower threshold:  0.25
Upper threshold:  0.8
Randomness:  0 %
Opening image...
Converting to RGBA...
Rotating image...
Getting data...
Getting pixels...
Determining intervals...
Defining intervals...
Sorting pixels...
Placing pixels in output image...
Rotating output image back to original orientation...
Crop image to apropriate size...
Saving image...
Done! Im1Xx.png
```

![im1xx](https://cloud.githubusercontent.com/assets/1406122/22854704/8a4e8c7a-f042-11e6-83d8-72074ca38e43.png)

