### PR TITLE
added saturation sort, removed redundant maximum, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Interval function 	| Description
 `threshold`			| Intervals defined by lightness thresholds; only pixels with a lightness between the upper and lower thresholds are sorted.
 `waves`				| Intervals are waves of nearly uniform widths. Control width of waves with `clength`.
 `file`				| Intervals taken from another specified input image. Must be black and white.
+`none`				| Sort whole rows, only stopping at image borders.
 
 
 #### Sorting Functions
@@ -60,8 +61,8 @@ Sorting function    | Description
 --------------------|------------
 `lightness`         | Sort by the lightness of a pixel according to a HSV representation.
 `hue`               | Sort by the hue of a pixel according to a HSV representation.
+`saturation`        | Sort by the saturation of a pixel according to a HSV representation.
 `intensity`         | Sort by the intensity of a pixel, i.e. the sum of all the RGB values.
-`maximum`           | Sort on the maximum RGB value of a pixel (either the R, G or B).
 `minimum`           | Sort on the minimum RGB value of a pixel (either the R, G or B).
 
 #### Examples

--- a/argparams.py
+++ b/argparams.py
@@ -29,8 +29,8 @@ def read_sorting_function():
             "lightness": sorting.lightness,
             "hue": sorting.hue,
             "intensity": sorting.intensity,
-            "maximum": sorting.maximum,
-            "minimum": sorting.minimum
+            "minimum": sorting.minimum,
+            "saturation": sorting.saturation
             }[__args.sorting_function]
     except KeyError:
         print("[WARNING] Invalid sorting function specified, defaulting to 'lightness'.")
@@ -47,7 +47,7 @@ p.add_argument("-u", "--upper_threshold", type=float, help="Pixels darker than t
 p.add_argument("-c", "--clength", type=int, help="Characteristic length of random intervals", default=50)
 p.add_argument("-a", "--angle", type=float, help="Rotate the image by an angle (in degrees) before sorting", default=0)
 p.add_argument("-r", "--randomness", type=float, help="What percentage of intervals are NOT sorted", default=0)
-p.add_argument("-s", "--sorting_function", help="lightness, intensity, hue, maximum, minimum", default="lightness")
+p.add_argument("-s", "--sorting_function", help="lightness, intensity, hue, saturation, minimum", default="lightness")
 __args = p.parse_args()
 
 image_input_path = __args.image

--- a/sorting.py
+++ b/sorting.py
@@ -13,8 +13,8 @@ def hue(pixel):
     return util.hue(pixel)
 
 
-def maximum(pixel):
-    return max(pixel[0], pixel[1], pixel[2])
+def saturation(pixel):
+    return util.saturation(pixel)
 
 
 def minimum(pixel):

--- a/util.py
+++ b/util.py
@@ -15,6 +15,10 @@ def hue(pixel):
     return rgb_to_hsv(pixel[0], pixel[1], pixel[2])[0] / 255.0
 
 
+def saturation(pixel):
+    return rgb_to_hsv(pixel[0], pixel[1], pixel[2])[1] / 255.0
+
+
 def random_width(clength):
     x = random.random()
     width = int(clength * (1 - x))


### PR DESCRIPTION
First of all, since the app is already using HSV, it may as well sort by saturation, too. It produces a grainy output similar to `minimum` and `hue`, but grain should be no criticism in glitch art. It is visually distinct from all other sorting methods - certainly more than `intensity` for example.

Maximum is removed, because it's simply redundant.  See https://github.com/satyarth/pixelsort/issues/7

Readme is updated to mention saturation sort and `none` - previously undocumented.