### PR TITLE
Fix for file intervals and angle

### DIFF
--- a/interval.py
+++ b/interval.py
@@ -105,6 +105,7 @@ def file_mask(pixels, args):
 
     img = Image.open(args.interval_file_path)
     img = img.convert('RGBA')
+    img = img.rotate(args.angle, expand=True)
     data = img.load()
     for y in range(img.size[1]):
         file_pixels.append([])


### PR DESCRIPTION
Previously using an external file mask and a non-zero angle would cause an error as the external mask file is never rotated as well. See #9 for an example.