### PR TITLE
Large refactor and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Have a look at [this post](http://satyarth.me/articles/pixel-sorting/) or [/r/pi
 
 Should work in both Python 2 and 3, but Python 3 is recommended.
 
-### Usage
+## Usage
 
 From the command line:
 
@@ -38,42 +38,42 @@ As a package:
 
 #### Parameters:
 
-Parameter 			| Flag 	| Description
---------------------|-------|------------
-Interval function 	| `-i`	| Controls how the intervals used for sorting are defined. See below for more details and examples.
-Output file 		| `-o`	| Path of output file. Randomly generates a file name by default.
-Randomness 			| `-r`	| What percentage of intervals *not* to sort. 0 by default.
-Threshold (lower) 	| `-t`	| How dark must a pixel be to be considered as a 'border' for sorting? Takes values from 0-1. 0.25 by default. Used in `edges` and `threshold` modes.
-Threshold (upper) 	| `-u`	| How bright must a pixel be to be considered as a 'border' for sorting? Takes values from 0-1. 0.8 by default. Used in `threshold` mode.
-Char. length		| `-c`	| Characteristic length for the random width generator. Used in mode `random`.
-Angle 				| `-a`	| Angle at which you're pixel sorting in degrees. `0` (horizontal) by default.
+Parameter 			        | Flag 	| Description
+------------------------|-------|------------
+Interval function     	| `-i`	| Controls how the intervals used for sorting are defined. See below for more details and examples. Threshold by default.
+Output path             | `-o`	| Path of output file. Uses the current time for the file name by default.
+Randomness 			        | `-r`	| What percentage of intervals *not* to sort. 0 by default.
+Threshold (lower)     	| `-t`	| How dark must a pixel be to be considered as a 'border' for sorting? Takes values from 0-1. 0.25 by default. Used in `edges` and `threshold` modes.
+Threshold (upper)     	| `-u`	| How bright must a pixel be to be considered as a 'border' for sorting? Takes values from 0-1. 0.8 by default. Used in `threshold` mode.
+Char. length		        | `-c`	| Characteristic length for the random width generator. Used in mode `random` and `waves`.
+Angle 				          | `-a`	| Angle at which you're pixel sorting in degrees. `0` (horizontal) by default.
 External interval file 	| `-f` 	| Image used to define intervals. Must be black and white.
-Sorting function    | `-s`  | Sorting function to use for sorting the pixels.
-Mask    | `-m`  | Image used for masking parts of the image.
-Logging Level    | `-l`  | Level of logging statements made visible. Choices include `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`.
+Sorting function        | `-s`  | Sorting function to use for sorting the pixels. Lightness by default.
+Mask                    | `-m`  | Image used for masking parts of the image.
+Logging level           | `-l`  | Level of logging statements made visible. Choices include `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`. `WARNING` by default.
 
 #### Interval Functions
 
-Interval function 	| Description
---------------------|------------
-`random`			| Randomly generate intervals. Distribution of widths is linear by default. Interval widths can be scaled using `clength`.
-`edges`				| Performs an edge detection, which is used to define intervals. Tweak threshold with `threshold`.
-`threshold`			| Intervals defined by lightness thresholds; only pixels with a lightness between the upper and lower thresholds are sorted.
-`waves`				| Intervals are waves of nearly uniform widths. Control width of waves with `clength`.
-`file`				| Intervals taken from another specified input image. Must be black and white, and the same size as the input image.
-`file-edges`		| Intevals defined by performing edge detection on the file specified by `-f`. Must be the same size as the input image.
-`none`				| Sort whole rows, only stopping at image borders.
+Interval function | Description
+------------------|------------
+`random`			    | Randomly generate intervals. Distribution of widths is linear by default. Interval widths can be scaled using `clength`.
+`edges`				    | Performs an edge detection, which is used to define intervals. Tweak threshold with `threshold`.
+`threshold`		  	| Intervals defined by lightness thresholds; only pixels with a lightness between the upper and lower thresholds are sorted.
+`waves`			    	| Intervals are waves of nearly uniform widths. Control width of waves with `clength`.
+`file`			    	| Intervals taken from another specified input image. Must be black and white, and the same size as the input image.
+`file-edges`	  	| Intevals defined by performing edge detection on the file specified by `-f`. Must be the same size as the input image.
+`none`			    	| Sort whole rows, only stopping at image borders.
 
 
 #### Sorting Functions
 
-Sorting function    | Description
---------------------|------------
-`lightness`         | Sort by the lightness of a pixel according to a HSV representation.
-`hue`               | Sort by the hue of a pixel according to a HSV representation.
-`saturation`        | Sort by the saturation of a pixel according to a HSV representation.
-`intensity`         | Sort by the intensity of a pixel, i.e. the sum of all the RGB values.
-`minimum`           | Sort on the minimum RGB value of a pixel (either the R, G or B).
+Sorting function  | Description
+------------------|------------
+`lightness`       | Sort by the lightness of a pixel according to a HSV representation.
+`hue`             | Sort by the hue of a pixel according to a HSV representation.
+`saturation`      | Sort by the saturation of a pixel according to a HSV representation.
+`intensity`       | Sort by the intensity of a pixel, i.e. the sum of all the RGB values.
+`minimum`         | Sort on the minimum RGB value of a pixel (either the R, G or B).
 
 #### Examples
 
@@ -81,7 +81,7 @@ Sorting function    | Description
 
 ![random](/examples/random.png)
 
-`python3 -m pixelsort examples/image.jpg -i edges -t 250`
+`python3 -m pixelsort examples/image.jpg -i edges -t .5`
 
 ![edges](/examples/edges.png)
 

--- a/pixelsort/argparams.py
+++ b/pixelsort/argparams.py
@@ -8,37 +8,70 @@ from pixelsort.constants import DEFAULTS
 def parse_args():
     parser = argparse.ArgumentParser(description="Pixel mangle an image.")
     parser.add_argument("image", help="Input image file path.")
-    parser.add_argument("-o", "--output",
-                        help="Output image file path, DEFAULTS to the time created.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output image file path, DEFAULTS to the time created.")
     parser.add_argument("-i", "--int_function",
                         choices=interval_choices.keys(),
                         default=DEFAULTS["interval_function"],
                         help="Function to determine sorting intervals")
     parser.add_argument("-f", "--int_file",
                         help="Image used for defining intervals.")
-    parser.add_argument("-t", "--threshold", type=float, default=DEFAULTS["lower_threshold"],
-                        help="Pixels darker than this are not sorted, between 0 and 1")
-    parser.add_argument("-u", "--upper_threshold", type=float, default=DEFAULTS["upper_threshold"],
-                        help="Pixels brighter than this are not sorted, between 0 and 1")
-    parser.add_argument("-c", "--clength", type=int, default=DEFAULTS["clength"],
-                        help="Characteristic length of random intervals")
-    parser.add_argument("-a", "--angle", type=float, default=DEFAULTS["angle"],
-                        help="Rotate the image by an angle (in degrees) before sorting")
-    parser.add_argument("-r", "--randomness", type=float, default=DEFAULTS["randomness"],
-                        help="What percentage of intervals are NOT sorted")
+    parser.add_argument(
+        "-t",
+        "--threshold",
+        type=float,
+        default=DEFAULTS["lower_threshold"],
+        help="Pixels darker than this are not sorted, between 0 and 1")
+    parser.add_argument(
+        "-u",
+        "--upper_threshold",
+        type=float,
+        default=DEFAULTS["upper_threshold"],
+        help="Pixels brighter than this are not sorted, between 0 and 1")
+    parser.add_argument(
+        "-c",
+        "--clength",
+        type=int,
+        default=DEFAULTS["clength"],
+        help="Characteristic length of random intervals")
+    parser.add_argument(
+        "-a",
+        "--angle",
+        type=float,
+        default=DEFAULTS["angle"],
+        help="Rotate the image by an angle (in degrees) before sorting")
+    parser.add_argument(
+        "-r",
+        "--randomness",
+        type=float,
+        default=DEFAULTS["randomness"],
+        help="What percentage of intervals are NOT sorted")
     parser.add_argument("-s", "--sorting_function",
                         choices=sorting_choices.keys(),
                         default=DEFAULTS["sorting_function"],
                         help="Function to sort pixels by.")
     parser.add_argument(
         "-m", "--mask", help="Image used for masking parts of the image")
-    parser.add_argument("-l", "--log_level", default="WARNING", help="Print more or less info",
-                        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+    parser.add_argument(
+        "-l",
+        "--log_level",
+        default="WARNING",
+        help="Print more or less info",
+        choices=[
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "ERROR",
+            "CRITICAL"])
 
     _args = parser.parse_args()
 
     logging.basicConfig(
-        format="%(name)s: %(levelname)s - %(message)s", level=logging.getLevelName(_args.log_level))
+        format="%(name)s: %(levelname)s - %(message)s",
+        level=logging.getLevelName(
+            _args.log_level))
 
     return {
         "image_input_path": _args.image,

--- a/pixelsort/constants.py
+++ b/pixelsort/constants.py
@@ -1,5 +1,3 @@
-BLACK_PIXEL = (0, 0, 0, 255)
-WHITE_PIXEL = (255, 255, 255, 255)
 DEFAULTS = {
     "interval_function": "threshold",
     "lower_threshold": 0.25,

--- a/pixelsort/main.py
+++ b/pixelsort/main.py
@@ -3,7 +3,7 @@ from PIL import Image
 
 from pixelsort.util import crop_to
 from pixelsort.sorter import sort_image
-from pixelsort.constants import DEFAULTS, BLACK_PIXEL
+from pixelsort.constants import DEFAULTS
 from pixelsort.interval import choices as interval_choices
 from pixelsort.sorting import choices as sorting_choices
 
@@ -21,78 +21,48 @@ def pixelsort(
     angle=DEFAULTS["angle"]
 ):
 
-    logging.debug("Cleaning input image...")
     original = image
     image = image.convert('RGBA').rotate(angle, expand=True)
+    image_data = image.load()
 
-    logging.debug("Getting data...")
-    input_data = image.load()
+    mask_image = mask_image if mask_image else Image.new(
+        "1", original.size, color=255)
 
-    mask_data = None
-    if mask_image:
-        logging.debug("Loading mask...")
-        mask_data = (mask_image
-                     .convert('RGBA')
-                     .rotate(angle, expand=True)
-                     .resize(image.size, Image.ANTIALIAS).load())
+    mask_data = (mask_image
+                 .convert('1')
+                 .rotate(angle, expand=True, fillcolor=0)
+                 .load())
 
-    if interval_image:
-        logging.debug("Loading interval image...")
-        (interval_image
-         .convert('RGBA')
-         .rotate(angle, expand=True)
-         .resize(image.size, Image.ANTIALIAS))
-
-    logging.debug("Getting pixels...")
-    pixels = _get_pixels(input_data, mask_data, image.size)
-
+    interval_image = (interval_image
+                      .convert('1')
+                      .rotate(angle, expand=True)) if interval_image else None
     logging.debug("Determining intervals...")
-    try:
-        interval_function = interval_choices[interval_function]
-    except KeyError:
-        logging.warning(
-            "Invalid interval function specified, defaulting to 'threshold'.")
-        interval_function = interval_choices["threshold"]
-    intervals = interval_function(
-        pixels,
+    intervals = interval_choices[interval_function](
+        image,
         lower_threshold=lower_threshold,
         upper_threshold=upper_threshold,
         clength=clength,
         interval_image=interval_image,
-        image=image
     )
-
     logging.debug("Sorting pixels...")
-    try:
-        sorting_function = sorting_choices[sorting_function]
-    except KeyError:
-        logging.warning(
-            "Invalid sorting function specified, defaulting to 'lightness'.")
-        sorting_function = sorting_choices["lightness"]
-    sorted_pixels = sort_image(pixels, intervals, randomness, sorting_function)
+    sorted_pixels = sort_image(
+        image.size,
+        image_data,
+        mask_data,
+        intervals,
+        randomness,
+        sorting_choices[sorting_function])
 
-    logging.debug("Placing pixels in output image...")
     output_img = _place_pixels(
-        sorted_pixels, mask_data, input_data, image.size)
-
+        sorted_pixels,
+        mask_data,
+        image_data,
+        image.size)
     if angle != 0:
-        logging.debug("Rotating output image back to original orientation...")
         output_img = output_img.rotate(-angle, expand=True)
-
-        logging.debug("Crop image to appropriate size...")
         output_img = crop_to(output_img, original)
 
     return output_img
-
-
-def _get_pixels(data, mask, size):
-    pixels = []
-    for y in range(size[1]):
-        pixels.append([])
-        for x in range(size[0]):
-            if not (mask and mask[x, y] == BLACK_PIXEL):
-                pixels[y].append(data[x, y])
-    return pixels
 
 
 def _place_pixels(pixels, mask, original, size):
@@ -100,7 +70,7 @@ def _place_pixels(pixels, mask, original, size):
     for y in range(size[1]):
         count = 0
         for x in range(size[0]):
-            if mask and mask[x, y] == BLACK_PIXEL:
+            if not mask[x, y]:
                 output_img.putpixel((x, y), original[x, y])
             else:
                 output_img.putpixel((x, y), pixels[y][count])

--- a/pixelsort/sorter.py
+++ b/pixelsort/sorter.py
@@ -1,15 +1,23 @@
 import random
 
 
-def sort_image(pixels, intervals, randomness, sorting_function):
+def sort_image(
+        size,
+        image_data,
+        mask_data,
+        intervals,
+        randomness,
+        sorting_function):
     sorted_pixels = []
-    for y in range(len(pixels)):
+
+    for y in range(size[1]):
         row = []
         x_min = 0
-        for x_max in intervals[y]:
+        for x_max in intervals[y] + [size[0]]:
             interval = []
             for x in range(x_min, x_max):
-                interval.append(pixels[y][x])
+                if mask_data[x, y]:
+                    interval.append(image_data[x, y])
             if random.random() < randomness / 100:
                 row += interval
             else:

--- a/pixelsort/util.py
+++ b/pixelsort/util.py
@@ -1,7 +1,6 @@
-import string
 from colorsys import rgb_to_hsv
-import random
 import time
+
 
 def id_generator():
     timestr = time.strftime("%Y%m%d-%H%M%S")
@@ -21,12 +20,6 @@ def saturation(pixel):
     return rgb_to_hsv(pixel[0], pixel[1], pixel[2])[1] / 255.0
 
 
-def random_width(clength):
-    x = random.random()
-    width = int(clength * (1 - x))
-    return width
-
-
 def crop_to(image_to_crop, reference_image):
     """
     Crops image to the size of a reference image. This function assumes that the relevant image is located in the center
@@ -43,4 +36,9 @@ def crop_to(image_to_crop, reference_image):
     upper = dy / 2
     right = dx / 2 + reference_size[0]
     lower = dy / 2 + reference_size[1]
-    return image_to_crop.crop(box=(int(left), int(upper), int(right), int(lower)))
+    return image_to_crop.crop(
+        box=(
+            int(left),
+            int(upper),
+            int(right),
+            int(lower)))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as fh:
 
 setuptools.setup(
     name="pixelsort",
-    version="1.0.0",
+    version="1.0.1",
     author="Bernard Zhao",
     author_email="bernardzhao@berkeley.edu",
     description="An image pixelsorter for Python.",


### PR DESCRIPTION
I should have broken this up into several commits, but each change seemed to go together.
* Fixed #23 by introducing a default mask. This isn't a complete solution to the problem though, using uneven angles that do not map backwards perfectly still drops pixels, even if we try bilinear or bicubic resampling functions. However, 135 degrees and other orthogonal angles work perfect now.
* Refactored masking to be more performant and also completely separate from the interval defining process
* Made interval processing much faster, avoiding multiple passes
* Removed unnecessary defaulting from the main script
* Changed masking image types into binary formats to avoid varying black and white pixel definitions

I also was using my own experimental integration test suite to make sure that these changes did not break basic functionality when compared to the live versions, which I'm thinking I should add when it's more flushed out. I also noticed in these changes that the `waves` interval function doesn't actually scale with clength very well while testing on large and small images, which is something else that should also be changed.

An even bigger consideration I begun thinking about was also how alpha should be handled. Currently none of the sorting functions consider that channel, except for PIL edge detection. What should happen to a blank pixel? Or two pixels of the same RGB values but with varying alpha?

Hopefully these changes also make creating a new interval function easier, the structure is a lot cleaner and easier to follow.