### PR TITLE
Prevent "Division by zero" in saturation

### DIFF
--- a/pixelsort/sorting.py
+++ b/pixelsort/sorting.py
@@ -43,13 +43,15 @@ def saturation(pixel: typing.Tuple[int, int, int]) -> float:
     r, g, b = pixel[:3]
     maxc = max(r, g, b)
     minc = min(r, g, b)
-    l = (minc + maxc) / 2.0
-    if minc == maxc:
+    sumc = minc+maxc
+    diffc = maxc-minc
+    l = sumc / 2.0
+    if minc == maxc or sumc == 0 or 2.0-diffc == 0
         return 0.0
     if l <= 0.5:
-        s = (maxc - minc) / (maxc + minc)
+        s = diffc / sumc
     else:
-        s = (maxc - minc) / (2.0 - maxc - minc)
+        s = diffc / (2.0 - diffc)
     return s
 
 

--- a/pixelsort/sorting.py
+++ b/pixelsort/sorting.py
@@ -43,15 +43,16 @@ def saturation(pixel: typing.Tuple[int, int, int]) -> float:
     r, g, b = pixel[:3]
     maxc = max(r, g, b)
     minc = min(r, g, b)
-    sumc = minc+maxc
-    diffc = maxc-minc
-    l = sumc / 2.0
-    if minc == maxc or sumc == 0 or 2.0-diffc == 0
+    sumc = minc + maxc
+    diffc = maxc - minc
+    sdiv = 2.0 - diffc
+
+    if minc == maxc or sumc == 0 or sdiv == 0:
         return 0.0
-    if l <= 0.5:
+    if sumc / 2.0 <= 0.5:
         s = diffc / sumc
     else:
-        s = diffc / (2.0 - diffc)
+        s = diffc / sdiv
     return s
 
 


### PR DESCRIPTION
Saturation gives on some values of minc and maxc a division zero error. This PR prevent this.